### PR TITLE
object files must be placed before -l option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ $(LIB): $(LIB_OBJ)
 	ar crs $@ $(LIB_OBJ)
 
 $(BIN): $(LIB) $(BIN_OBJ)
-	$(CXX) $(LDFLAGS) $(BIN_OBJ) -o $@ $(LIB) $(LIBRARY)
+	$(CXX) $(BIN_OBJ) -o $@ $(LIB) $(LIBRARY) $(LDFLAGS)
 
 %.o: %.cpp
 	$(CXX) $(CXXFLAGS) -c$< -o $@


### PR DESCRIPTION
要把-l放到后面才行，不然ubunut 12.04 32bit gcc 4.6.3 链接时时找不到pthread 和zlib的函数
