### PR TITLE
Using _LOGGING_H_ macro to avoid conflict

### DIFF
--- a/src/sofa/pbrpc/common.h
+++ b/src/sofa/pbrpc/common.h
@@ -99,7 +99,7 @@ void log_handler(LogLevel level, const char* filename, int line, const char *fmt
     !(condition) ? (void)0 : ::sofa::pbrpc::internal::log_handler( \
             ::sofa::pbrpc::LOG_LEVEL_##level, __FILE__, __LINE__, fmt, ##arg)
 
-#if defined( LOG )
+#if defined( _LOGGING_H_ )
 #define SCHECK(expression) CHECK(expression)
 #define SCHECK_EQ(a, b) CHECK_EQ(a, b)
 #define SCHECK_NE(a, b) CHECK_NE(a, b)


### PR DESCRIPTION
这里应该是和glog相关的，common库中也有LOG这个宏，应用可能同时依赖于common库和sofa-pbrpc，为了避免编译时的冲突，于是改成了判断_LOGGING_H_，这是glog中头文件的宏