### PR TITLE
extend buf handle size

### DIFF
--- a/src/sofa/pbrpc/binary_rpc_request_parser.cc
+++ b/src/sofa/pbrpc/binary_rpc_request_parser.cc
@@ -46,7 +46,7 @@ bool BinaryRpcRequestParser::CheckMagicString(const char* magic_string)
 }
 
 int BinaryRpcRequestParser::Parse(const char* buf,
-        int data_size, int offset, int* bytes_consumed)
+        int buf_size, int data_size, int offset, int* bytes_consumed)
 {
     if (data_size == 0)
     {
@@ -85,7 +85,7 @@ int BinaryRpcRequestParser::Parse(const char* buf,
         case PS_MSG_BODY:
             bytes_remain = _req->_req_header.message_size - _bytes_recved;
             consume = std::min(data_size, bytes_remain);
-            _req->_req_body->Append(BufHandle(const_cast<char*>(buf), consume, offset));
+            _req->_req_body->Append(BufHandle(const_cast<char*>(buf), consume, offset, buf_size));
             *bytes_consumed += consume;
             _bytes_recved += consume;
             if (_bytes_recved == _req->_req_header.message_size)

--- a/src/sofa/pbrpc/binary_rpc_request_parser.h
+++ b/src/sofa/pbrpc/binary_rpc_request_parser.h
@@ -25,7 +25,7 @@ public:
 
     virtual bool CheckMagicString(const char* magic_string);
 
-    virtual int Parse(const char* buf, int data_size, int offset, int* bytes_consumed);
+    virtual int Parse(const char* buf, int buf_size, int data_size, int offset, int* bytes_consumed);
 
     virtual RpcRequestPtr GetRequest();
 

--- a/src/sofa/pbrpc/buf_handle.h
+++ b/src/sofa/pbrpc/buf_handle.h
@@ -14,19 +14,19 @@ struct BufHandle
 {
     char* data; // block header
     int   size; // data size
-    union {
-        int capacity; // block capacity, used by WriteBuffer
-        int offset;   // start position in the block, used by ReadBuffer
-    };
+    int capacity; // block capacity, used by WriteBuffer
+    int offset;   // start position in the block, used by ReadBuffer
 
     BufHandle(char* _data, int _capacity)
         : data(_data)
         , size(0)
-        , capacity(_capacity) {}
+        , capacity(_capacity)
+        , offset(0) {}
 
-    BufHandle(char* _data, int _size, int _offset)
+    BufHandle(char* _data, int _size, int _offset, int _capacity)
         : data(_data)
         , size(_size)
+        , capacity(_capacity)
         , offset(_offset) {}
 }; // class BufHandle
 

--- a/src/sofa/pbrpc/buffer.h
+++ b/src/sofa/pbrpc/buffer.h
@@ -50,6 +50,9 @@ public:
     // Get the block count occupied by the buffer.
     int BlockCount() const;
 
+    // Get the total size of blocks occupied by the buffer.
+    int64 TotalBlockSize() const;
+
     // Trans buffer to string.
     std::string ToString() const;
 
@@ -66,6 +69,7 @@ private:
     int _cur_pos;
     int _last_bytes; // last read bytes
     int64 _read_bytes; // total read bytes
+    int64 _total_block_size; // total size of all blocks
 
     SOFA_PBRPC_DISALLOW_EVIL_CONSTRUCTORS(ReadBuffer);
 }; // class ReadBuffer

--- a/src/sofa/pbrpc/http_rpc_request_parser.cc
+++ b/src/sofa/pbrpc/http_rpc_request_parser.cc
@@ -51,7 +51,7 @@ bool HTTPRpcRequestParser::CheckMagicString(const char* magic_string)
 }
 
 int HTTPRpcRequestParser::Parse(const char* buf,
-        int data_size, int offset, int* bytes_consumed)
+        int buf_size, int data_size, int offset, int* bytes_consumed)
 {
     if (data_size == 0)
     {
@@ -99,7 +99,7 @@ int HTTPRpcRequestParser::Parse(const char* buf,
             return 0;
         }
         int consume = std::min(data_size, bytes_remain);
-        _req->_req_body->Append(BufHandle(const_cast<char*>(buf), consume, offset));
+        _req->_req_body->Append(BufHandle(const_cast<char*>(buf), consume, offset, buf_size));
         *bytes_consumed += consume;
         if (_content_length == _req->_req_body->TotalCount())
         {

--- a/src/sofa/pbrpc/http_rpc_request_parser.h
+++ b/src/sofa/pbrpc/http_rpc_request_parser.h
@@ -25,7 +25,7 @@ public:
 
     virtual bool CheckMagicString(const char* magic_string);
 
-    virtual int Parse(const char* buf, int data_size, int offset, int* bytes_consumed);
+    virtual int Parse(const char* buf, int buf_size, int data_size, int offset, int* bytes_consumed);
 
     virtual RpcRequestPtr GetRequest();
 

--- a/src/sofa/pbrpc/rpc_message_stream.h
+++ b/src/sofa/pbrpc/rpc_message_stream.h
@@ -361,7 +361,7 @@ private:
         _pending_calls.push_back(PendingItem(message, cookie));
         ++_pending_message_count;
         _pending_data_size += message->TotalCount();
-        _pending_buffer_size += message->BlockCount() * TranBufPool::block_size();
+        _pending_buffer_size += message->TotalBlockSize();
     }
 
     // Insert an item into front of the pending queue.
@@ -376,7 +376,7 @@ private:
         _swapped_calls.push_front(PendingItem(message, cookie));
         ++_swapped_message_count;
         _swapped_data_size += message->TotalCount();
-        _swapped_buffer_size += message->BlockCount() * TranBufPool::block_size();
+        _swapped_buffer_size += message->TotalBlockSize();
     }
 
     // Get an item from the pending queue.
@@ -413,7 +413,7 @@ private:
             // update stats
             --_swapped_message_count;
             _swapped_data_size -= (*message)->TotalCount();
-            _swapped_buffer_size -= (*message)->BlockCount() * TranBufPool::block_size();
+            _swapped_buffer_size -= (*message)->TotalBlockSize();
             return true;
         }
 
@@ -586,7 +586,8 @@ private:
             if (_received_message_size + size < message_size)
             {
                 // all the remaining data belongs to the in-complete message
-                _receiving_message->Append(BufHandle(_tran_buf, size, data - _tran_buf));
+                _receiving_message->Append(BufHandle(_tran_buf,
+                        size, data - _tran_buf, TranBufPool::block_size()));
                 _received_message_size += size;
                 return true;
             }
@@ -594,7 +595,8 @@ private:
             int64 consume_size = message_size - _received_message_size;
             if (consume_size > 0)
             {
-                _receiving_message->Append(BufHandle(_tran_buf, consume_size, data - _tran_buf));
+                _receiving_message->Append(BufHandle(_tran_buf,
+                        consume_size, data - _tran_buf, TranBufPool::block_size()));
             }
             received_messages->push_back(ReceivedItem(_receiving_message, 
                         _receiving_header.meta_size, _receiving_header.data_size));

--- a/src/sofa/pbrpc/rpc_request_parser.h
+++ b/src/sofa/pbrpc/rpc_request_parser.h
@@ -35,6 +35,7 @@ public:
     // Parse received data.
     //
     // @param buf  buffer start address (must be a tran buf)
+    // @param buf_size  buffer size
     // @param data_size  data size
     // @param offset  the offset between real data and buffer start address
     // @param bytes_consumed  bytes used by this request
@@ -42,7 +43,8 @@ public:
     // @retval 1  request data ready
     // @retval 0  there are more bytes to be read
     // @retval -1  parse request fail
-    virtual int Parse(const char* buf, int data_size, int offset, int* bytes_consumed) = 0;
+    virtual int Parse(const char* buf, int buf_size,
+                int data_size, int offset, int* bytes_consumed) = 0;
 
     // Get the parsed request data.
     //

--- a/src/sofa/pbrpc/rpc_server_message_stream.h
+++ b/src/sofa/pbrpc/rpc_server_message_stream.h
@@ -362,7 +362,7 @@ private:
         _pending_calls.push_back(PendingItem(message, cookie));
         ++_pending_message_count;
         _pending_data_size += message->TotalCount();
-        _pending_buffer_size += message->BlockCount() * TranBufPool::block_size();
+        _pending_buffer_size += message->TotalBlockSize();
     }
 
     // Insert an item into front of the pending queue.
@@ -377,7 +377,7 @@ private:
         _swapped_calls.push_front(PendingItem(message, cookie));
         ++_swapped_message_count;
         _swapped_data_size += message->TotalCount();
-        _swapped_buffer_size += message->BlockCount() * TranBufPool::block_size();
+        _swapped_buffer_size += message->TotalBlockSize();
     }
 
     // Get an item from the pending queue.
@@ -414,7 +414,7 @@ private:
             // update stats
             --_swapped_message_count;
             _swapped_data_size -= (*message)->TotalCount();
-            _swapped_buffer_size -= (*message)->BlockCount() * TranBufPool::block_size();
+            _swapped_buffer_size -= (*message)->TotalBlockSize();
             return true;
         }
 
@@ -580,7 +580,7 @@ private:
                 }
             }
             int ret = _current_rpc_request_parser->Parse(
-                    _tran_buf, size, data - _tran_buf, &consumed);
+                    _tran_buf, TranBufPool::block_size(), size, data - _tran_buf, &consumed);
             _cur_recved_bytes += consumed;
             if (ret == 0)
             {

--- a/src/sofa/pbrpc/tran_buf_pool.h
+++ b/src/sofa/pbrpc/tran_buf_pool.h
@@ -10,7 +10,7 @@
 #include <sofa/pbrpc/common_internal.h>
 
 #ifndef SOFA_PBRPC_TRAN_BUF_BLOCK_SIZE
-#define SOFA_PBRPC_TRAN_BUF_BLOCK_SIZE (1024u - sizeof(RefCountType))
+#define SOFA_PBRPC_TRAN_BUF_BLOCK_SIZE (1024u)
 #endif
 
 namespace sofa {
@@ -24,18 +24,22 @@ public:
     typedef int RefCountType;
 
     // Get the size of single block.
-    inline static int block_size() 
+    inline static int block_size(int factor = 1)
     {
-        return static_cast<int>(SOFA_PBRPC_TRAN_BUF_BLOCK_SIZE);
+        SCHECK_GT(factor, 0);
+        SCHECK_LT(factor, (1 << 20));
+        return static_cast<int>(SOFA_PBRPC_TRAN_BUF_BLOCK_SIZE) * factor - sizeof(RefCountType);
     }
 
     // Allocate a block.  Return NULL if failed.
     //
     // Postconditions:
     // * If succeed, the reference count of the block is equal to 1.
-    inline static void * malloc()
+    inline static void * malloc(int factor = 1)
     {
-        void * p = ::malloc(SOFA_PBRPC_TRAN_BUF_BLOCK_SIZE + sizeof(RefCountType));
+        SCHECK_GT(factor, 0);
+        SCHECK_LT(factor, (1 << 20));
+        void * p = ::malloc(SOFA_PBRPC_TRAN_BUF_BLOCK_SIZE * factor);
         if (p != NULL)
         {
             *(reinterpret_cast<RefCountType*>(p)) = 1;


### PR DESCRIPTION
issue #31
主要改动：
1. tran_buf_pool的malloc函数增加factor参数，作为SOFA_PBRPC_TRAN_BUF_BLOCK_SIZE的系数
2. BufHandle的buffer大小改为不固定
3. WriteBuffer扩展时新分配的tranbuf大小按照指数增长（1k、2k、4k、...），直到最大值（32k）
