### PR TITLE
Fix compiler complaining about snprintf's parameter

### DIFF
--- a/src/sofa/pbrpc/ptime.h
+++ b/src/sofa/pbrpc/ptime.h
@@ -50,7 +50,7 @@ inline std::string ptime_to_string(const PTime& t)
     PTime::date_type date = lt.date();
     TimeDuration tod = lt.time_of_day();
     char buf[64];
-    snprintf(buf, sizeof(buf), "%04d-%02d-%02d %02d:%02d:%02d.%06lld",
+    snprintf(buf, sizeof(buf), "%04d-%02d-%02d %02d:%02d:%02d.%06ld",
             (int)date.year(),
             (int)date.month(),
             (int)date.day(),


### PR DESCRIPTION
`long fractional_seconds()` 返回的是long类型，使用%ld即可