### PR TITLE
Fix SetData function when data size exceed base block size

### DIFF
--- a/src/sofa/pbrpc/buffer.cc
+++ b/src/sofa/pbrpc/buffer.cc
@@ -252,6 +252,7 @@ void WriteBuffer::SetData(int64 pos, const char* data, int size)
         {
             memcpy(cur_it->data + cur_offset, data, cur_size);
             size -= cur_size;
+            data += cur_size;
             ++cur_it;
             cur_offset = 0;
         }

--- a/unit-test/test_buffer.cc
+++ b/unit-test/test_buffer.cc
@@ -441,6 +441,17 @@ TEST_F(WriteBufferTest, SetData)
         ASSERT_EQ(10, os->Reserve(32));
         os->SetData(10, _block, 32);
     }
+    {
+        WriteBufferPtr os(new WriteBuffer());
+        std::string str1(2000, 'x');
+        std::string str2(2000, 'y');
+        str1 += str2;
+        int head_pos = os->Reserve(str1.size());
+        os->SetData(head_pos, str1.c_str(), str1.size());
+        ReadBufferPtr is(new ReadBuffer());
+        os->SwapOut(is.get());
+        ASSERT_EQ(str1, is->ToString());
+    }
 }
 
 class PBSerDeserTest : public ::testing::Test


### PR DESCRIPTION
`WriteBuffer`填充数据时没有移动data指针