### PR TITLE
mac下开启detail log编译不过

### DIFF
--- a/src/sofa/pbrpc/common.cc
+++ b/src/sofa/pbrpc/common.cc
@@ -63,7 +63,7 @@ void default_log_handler(
             t.tm_min,
             t.tm_sec,
             static_cast<int>(now_tv.tv_usec),
-            static_cast<long long unsigned int>(pthread_self()),
+            reinterpret_cast<long long unsigned int>(pthread_self()),
             filename, line, buf);
 #else
     fprintf(stderr, "libsofa_pbrpc %s %s:%d] %s\n",

--- a/src/sofa/pbrpc/common.cc
+++ b/src/sofa/pbrpc/common.cc
@@ -63,7 +63,14 @@ void default_log_handler(
             t.tm_min,
             t.tm_sec,
             static_cast<int>(now_tv.tv_usec),
-            pthread_self(),
+#if (defined(__MACH__) && defined(__APPLE__)) \
+    || defined(__FreeBSD__) \
+    || defined(__NetBSD__) \
+    || defined(__OpenBSD__)
+            reinterpret_cast<long long unsigned int>(pthread_self()),
+#else
+            static_cast<long long unsigned int>(pthread_self()),
+#endif
             filename, line, buf);
 #else
     fprintf(stderr, "libsofa_pbrpc %s %s:%d] %s\n",

--- a/src/sofa/pbrpc/common.cc
+++ b/src/sofa/pbrpc/common.cc
@@ -63,7 +63,7 @@ void default_log_handler(
             t.tm_min,
             t.tm_sec,
             static_cast<int>(now_tv.tv_usec),
-            reinterpret_cast<long long unsigned int>(pthread_self()),
+            pthread_self(),
             filename, line, buf);
 #else
     fprintf(stderr, "libsofa_pbrpc %s %s:%d] %s\n",


### PR DESCRIPTION
## 现象
mac下开启SOFA_PBRPC_ENABLE_DETAILED_LOGGING，导致编译不通过
## 原因
pthread_self()返回值pthread_t在linux平台定义为unsigned long int(/usr/include/bits/pthreadtypes.h),
但是在mac上定义为struct _opaque_pthread_t\*, BSD系列的系统上为其他结构体指针（如FreeBSD : pthread*）因此不能采用static_cast转换。
## 解决方法
采用条件编译，判断在os x和BSD系列的平台上编译，采用reinterpret_cast的方式转换, linux平台仍然用static_cast转换。