### PR TITLE
Makefile add -Wno-unused-parameter flag, fix unused parameter warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ endif
 
 CXX=g++
 INCPATH=-Isrc -I$(BOOST_HEADER_DIR) -I$(PROTOBUF_DIR)/include -I$(SNAPPY_DIR)/include -I$(ZLIB_DIR)/include
-CXXFLAGS += $(OPT) -pipe -W -Wall -fPIC -D_GNU_SOURCE -D__STDC_LIMIT_MACROS -DHAVE_SNAPPY $(INCPATH)
+CXXFLAGS += $(OPT) -pipe -W -Wall -fPIC -D_GNU_SOURCE -D__STDC_LIMIT_MACROS -DHAVE_SNAPPY $(INCPATH) -Wno-unused-parameter
 
 LDFLAGS += -L$(ZLIB_DIR)/lib -L$(PROTOBUF_DIR)/lib/ -L$(SNAPPY_DIR)/lib/ -lprotobuf -lsnappy -lpthread -lz
 


### PR DESCRIPTION
在 centos， gcc4.8.5 下编译sofa-pbrpc ，有大量 unused parameter warning， 给Makefile CXXFLAGS 添加 -Wno-unused-parameter， 消除警告