### PR TITLE
remove redundant semicolon when printing log

### DIFF
--- a/src/sofa/pbrpc/rpc_request.cc
+++ b/src/sofa/pbrpc/rpc_request.cc
@@ -112,7 +112,7 @@ void RpcRequest::OnCallMethodDone(
                      << " {" << cntl->SequenceId() << "}"
                      << ": call method \"" << cntl->MethodId() << "\" timeout, not response"
                      << ": server_timeout_us=" << (cntl->ServerTimeout() * 1000)
-                     << ", server_used_time_us=" << server_used_time_us;
+                     << ", server_used_time_us=" << server_used_time_us
                      << ", process_time_us=" << process_time_us;
 #else
         SLOG(WARNING, "OnCallMethodDone(): %s {%lu}: call method \"%s\" timeout, not response: "


### PR DESCRIPTION
fix bug #143 