### PR TITLE
memory profiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,7 @@ OPT ?= -O2        # (A) Production use (optimized mode)
 #   SOFA_PBRPC_ENABLE_DETAILED_LOGGING : print current-time and thread-id in logging header
 #   SOFA_PBRPC_ENABLE_FUNCTION_TRACE : print trace log when enter and leave function
 #   SOFA_PBRPC_USE_SPINLOCK : use SpinLock as FastLock
-#   SOFA_PBRPC_CPU_PROFILING : use cpu profiling
-#   SOFA_PBRPC_HEAP_PROFILING : use heap profiling
+#   SOFA_PBRPC_PROFILING : use profiling
 #
 CXXFLAGS ?= -DSOFA_PBRPC_ENABLE_DETAILED_LOGGING
 #-----------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ CXX=g++
 INCPATH=-Isrc -I$(BOOST_HEADER_DIR) -I$(PROTOBUF_DIR)/include -I$(SNAPPY_DIR)/include -I$(ZLIB_DIR)/include
 CXXFLAGS += $(OPT) -pipe -W -Wall -fPIC -D_GNU_SOURCE -D__STDC_LIMIT_MACROS -DHAVE_SNAPPY $(INCPATH)
 
-LDFLAGS += -L$(ZLIB_DIR)/lib -L$(PROTOBUF_DIR)/lib/ -L$(SNAPPY_DIR)/lib/ -lprotobuf -lsnappy -pthread -lz
+LDFLAGS += -L$(ZLIB_DIR)/lib -L$(PROTOBUF_DIR)/lib/ -L$(SNAPPY_DIR)/lib/ -lprotobuf -lsnappy -lpthread -lz
 
 .PHONY: check_depends build rebuild install clean
 

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ OPT ?= -O2        # (A) Production use (optimized mode)
 #   SOFA_PBRPC_ENABLE_DETAILED_LOGGING : print current-time and thread-id in logging header
 #   SOFA_PBRPC_ENABLE_FUNCTION_TRACE : print trace log when enter and leave function
 #   SOFA_PBRPC_USE_SPINLOCK : use SpinLock as FastLock
+#   SOFA_PBRPC_CPU_PROFILING : use cpu profiling
+#   SOFA_PBRPC_HEAP_PROFILING : use heap profiling
 #
 CXXFLAGS ?= -DSOFA_PBRPC_ENABLE_DETAILED_LOGGING
 #-----------------------------------------------
@@ -79,7 +81,7 @@ CXX=g++
 INCPATH=-Isrc -I$(BOOST_HEADER_DIR) -I$(PROTOBUF_DIR)/include -I$(SNAPPY_DIR)/include -I$(ZLIB_DIR)/include
 CXXFLAGS += $(OPT) -pipe -W -Wall -fPIC -D_GNU_SOURCE -D__STDC_LIMIT_MACROS -DHAVE_SNAPPY $(INCPATH)
 
-LDFLAGS += -L$(ZLIB_DIR)/lib -L$(PROTOBUF_DIR)/lib/ -L$(SNAPPY_DIR)/lib/ -lprotobuf -lsnappy -lpthread -lz
+LDFLAGS += -L$(ZLIB_DIR)/lib -L$(PROTOBUF_DIR)/lib/ -L$(SNAPPY_DIR)/lib/ -lprotobuf -lsnappy -pthread -lz
 
 .PHONY: check_depends build rebuild install clean
 

--- a/src/sofa/pbrpc/profiling.cc
+++ b/src/sofa/pbrpc/profiling.cc
@@ -433,15 +433,15 @@ std::string Profiling::ShowResult(ProfilingType profiling_type,
     oss << viz_min_js;
     oss << "</script>";
     oss << "<script type=\"text/javascript\">\n";
-    oss << "function onViewChanged(obj) {\n";
-    oss << "  window.location.href = "
-        << "'/profiling?' + obj.title + '=page&prof=' + obj.value;\n";
-    oss << "}\n";
-    oss << "function onDiffChanged(obj) {\n";
-    oss << "  var profiling_file = document.getElementById('view_" << profiling_type_str << "').value;";
-    oss << "  window.location.href = "
-        << "'/profiling?' + obj.title + '=diff&prof=' + profiling_file + '&base=' + obj.value;\n";
-    oss << "}\n";
+    oss << "function onViewChanged(obj) {\n"
+        << "  window.location.href = "
+        << "  '/profiling?' + obj.title + '=page&prof=' + obj.value;\n"
+        << "}\n";
+    oss << "function onDiffChanged(obj) {\n"
+        << "  var profiling_file = document.getElementById('view_" << profiling_type_str << "').value;\n"
+        << "  window.location.href = "
+        << "  '/profiling?' + obj.title + '=diff&prof=' + profiling_file + '&base=' + obj.value;\n"
+        << "}\n";
     oss << "</script>";
     oss << "</head>";
 

--- a/src/sofa/pbrpc/profiling.cc
+++ b/src/sofa/pbrpc/profiling.cc
@@ -435,12 +435,12 @@ std::string Profiling::ShowResult(ProfilingType profiling_type,
     oss << "<script type=\"text/javascript\">\n";
     oss << "function onViewChanged(obj) {\n"
         << "  window.location.href = "
-        << "  '/profiling?' + obj.title + '=page&prof=' + obj.value;\n"
+        << "'/profiling?' + obj.title + '=page&prof=' + obj.value;\n"
         << "}\n";
     oss << "function onDiffChanged(obj) {\n"
         << "  var profiling_file = document.getElementById('view_" << profiling_type_str << "').value;\n"
         << "  window.location.href = "
-        << "  '/profiling?' + obj.title + '=diff&prof=' + profiling_file + '&base=' + obj.value;\n"
+        << "'/profiling?' + obj.title + '=diff&prof=' + profiling_file + '&base=' + obj.value;\n"
         << "}\n";
     oss << "</script>";
     oss << "</head>";

--- a/src/sofa/pbrpc/profiling.cc
+++ b/src/sofa/pbrpc/profiling.cc
@@ -201,8 +201,8 @@ Profiling::~Profiling()
 
 std::string Profiling::ProfilingPage(ProfilingType profiling_type, 
                                      DataType data_type,
-                                     std::string& prof_file,
-                                     std::string& prof_base)
+                                     std::string& profiling_file,
+                                     std::string& profiling_base)
 {
     std::ostringstream oss;
     oss << "<html><h1>Sofa-pbrpc Profiling</h1>";
@@ -223,12 +223,12 @@ std::string Profiling::ProfilingPage(ProfilingType profiling_type,
             {
                 oss.str("");
                 oss.clear();
-                std::string cmd = "perl " + _dir.path + "/rpc_profiling/pprof.perl --dot " 
-                         + _dir.path + "/" + _dir.name + " " + _dir.path 
-                         + CPU_PROFILING_PATH + prof_file;
-                if (!prof_base.empty())
+                std::string cmd = "perl " + _dir.path + "/rpc_profiling/pprof.perl --dot "
+                         + _dir.path + "/" + _dir.name + " " + _dir.path
+                         + CPU_PROFILING_PATH + profiling_file;
+                if (!profiling_base.empty())
                 {
-                    cmd.append(" --base " + _dir.path + CPU_PROFILING_PATH + prof_base);
+                    cmd.append(" --base " + _dir.path + CPU_PROFILING_PATH + profiling_base);
                 }
                 std::string dot = exec(cmd);
                 oss << dot;
@@ -236,23 +236,23 @@ std::string Profiling::ProfilingPage(ProfilingType profiling_type,
             }
             else if (data_type == CLEANUP)
             {
-                std::set<std::string> prof_files;
-                ListFile(_dir.path + CPU_PROFILING_PATH, prof_files);
-                for (std::set<std::string>::iterator it = prof_files.begin();
-                        it != prof_files.end(); ++it)
+                std::set<std::string> profiling_set;
+                ListFile(_dir.path + CPU_PROFILING_PATH, profiling_set);
+                for (std::set<std::string>::iterator it = profiling_set.begin();
+                        it != profiling_set.end(); ++it)
                 {
                     std::string profiling_path(_dir.path + CPU_PROFILING_PATH + *it);
                     ::remove(profiling_path.c_str());
                 }
-                oss << ShowResult(profiling_type, prof_file, prof_base); 
+                oss << ShowResult(profiling_type, profiling_file, profiling_base);
             }
             else if (data_type == DIFF)
             {
-                oss << ShowResult(profiling_type, prof_file, prof_base); 
+                oss << ShowResult(profiling_type, profiling_file, profiling_base);
             }
             else
             {
-                Status ret = DoCpuProfiling(data_type, prof_file);
+                Status ret = DoCpuProfiling(data_type, profiling_file);
                 if (ret == DISABLE)
                 {
                     oss << "<h2>To enable profiling, please add compile and link options when compiling binary:</h2>";
@@ -274,7 +274,7 @@ std::string Profiling::ProfilingPage(ProfilingType profiling_type,
                 }
                 else if (ret == FINISHED)
                 {
-                    oss << ShowResult(profiling_type, prof_file, prof_base);
+                    oss << ShowResult(profiling_type, profiling_file, profiling_base);
                 }
                 else
                 {
@@ -290,12 +290,12 @@ std::string Profiling::ProfilingPage(ProfilingType profiling_type,
             {
                 oss.str("");
                 oss.clear();
-                std::string cmd = "perl " + _dir.path + "/rpc_profiling/pprof.perl --dot " 
-                         + _dir.path + "/" + _dir.name + " " + _dir.path 
-                         + HEAP_PROFILING_PATH + prof_file;
-                if (!prof_base.empty())
+                std::string cmd = "perl " + _dir.path + "/rpc_profiling/pprof.perl --dot "
+                         + _dir.path + "/" + _dir.name + " " + _dir.path
+                         + HEAP_PROFILING_PATH + profiling_file;
+                if (!profiling_base.empty())
                 {
-                    cmd.append(" --base " + _dir.path + HEAP_PROFILING_PATH + prof_base);
+                    cmd.append(" --base " + _dir.path + HEAP_PROFILING_PATH + profiling_base);
                 }
                 std::string dot = exec(cmd);
                 oss << dot;
@@ -303,23 +303,23 @@ std::string Profiling::ProfilingPage(ProfilingType profiling_type,
             }
             else if (data_type == CLEANUP)
             {
-                std::set<std::string> prof_files;
-                ListFile(_dir.path + HEAP_PROFILING_PATH, prof_files);
-                for (std::set<std::string>::iterator it = prof_files.begin();
-                        it != prof_files.end(); ++it)
+                std::set<std::string> profiling_set;
+                ListFile(_dir.path + HEAP_PROFILING_PATH, profiling_set);
+                for (std::set<std::string>::iterator it = profiling_set.begin();
+                        it != profiling_set.end(); ++it)
                 {
                     std::string profiling_path(_dir.path + HEAP_PROFILING_PATH + *it);
                     ::remove(profiling_path.c_str());
                 }
-                oss << ShowResult(profiling_type, prof_file, prof_base); 
+                oss << ShowResult(profiling_type, profiling_file, profiling_base);
             }
             else if (data_type == DIFF)
             {
-                oss << ShowResult(profiling_type, prof_file, prof_base); 
+                oss << ShowResult(profiling_type, profiling_file, profiling_base);
             }
             else
             {
-                Status ret = DoMemoryProfiling(data_type, prof_file);
+                Status ret = DoMemoryProfiling(data_type, profiling_file);
                 if (ret == DISABLE)
                 {
                     oss << "<h2>To enable memory profiling, please add compile and link options when compiling binary:</h2>";
@@ -341,7 +341,7 @@ std::string Profiling::ProfilingPage(ProfilingType profiling_type,
                 }
                 else if (ret == FINISHED)
                 {
-                    oss << ShowResult(profiling_type, prof_file, prof_base);
+                    oss << ShowResult(profiling_type, profiling_file, profiling_base);
                 }
                 else
                 {
@@ -363,7 +363,7 @@ std::string Profiling::ProfilingPage(ProfilingType profiling_type,
     return oss.str();
 }
 
-Profiling::Status Profiling::DoCpuProfiling(DataType data_type, std::string& prof_file)
+Profiling::Status Profiling::DoCpuProfiling(DataType data_type, std::string& profiling_file)
 {
     if (ProfilerStart == NULL)
     {
@@ -375,12 +375,16 @@ Profiling::Status Profiling::DoCpuProfiling(DataType data_type, std::string& pro
         return PROFILING;
     }
 
-    std::set<std::string> prof_files;
-    ListFile(_dir.path + CPU_PROFILING_PATH, prof_files);
+    std::set<std::string> profiling_set;
+    ListFile(_dir.path + CPU_PROFILING_PATH, profiling_set);
 
-    if (prof_file == "default" && !prof_files.empty() && data_type != NEW_GRAPH)
+    if (profiling_file == "default" && !profiling_set.empty() && data_type != NEW_GRAPH)
     {
-        prof_file = *(prof_files.rbegin());
+        profiling_file = *(profiling_set.rbegin());
+        return FINISHED;
+    }
+    if (IsFileExist(_dir.path + CPU_PROFILING_PATH + profiling_file))
+    {
         return FINISHED;
     }
     _is_cpu_profiling = true;
@@ -391,8 +395,8 @@ Profiling::Status Profiling::DoCpuProfiling(DataType data_type, std::string& pro
     return OK;
 }
 
-std::string Profiling::ShowResult(ProfilingType profiling_type, 
-        const std::string& prof_file, const std::string& prof_base)
+std::string Profiling::ShowResult(ProfilingType profiling_type,
+        const std::string& profiling_file, const std::string& profiling_base)
 {
     std::ostringstream oss;
     std::string path = _dir.path + "/rpc_profiling/pprof.perl";
@@ -403,25 +407,25 @@ std::string Profiling::ShowResult(ProfilingType profiling_type,
         ofs.close();
     }
 
-    std::string prof_type;
-    std::string prof_path;
+    std::string profiling_type_str;
+    std::string profiling_path;
     if (profiling_type == CPU)
     {
-        prof_type = "cpu";
-        prof_path = _dir.path + CPU_PROFILING_PATH;
+        profiling_type_str = "cpu";
+        profiling_path = _dir.path + CPU_PROFILING_PATH;
     }
     else if (profiling_type == MEMORY)
     {
-        prof_type = "memory";
-        prof_path = _dir.path + HEAP_PROFILING_PATH;
+        profiling_type_str = "memory";
+        profiling_path = _dir.path + HEAP_PROFILING_PATH;
     }
     else
     {
-        prof_type = "";
+        profiling_type_str = "";
     }
 
-    std::set<std::string> prof_files;
-    ListFile(prof_path, prof_files);
+    std::set<std::string> profiling_set;
+    ListFile(profiling_path, profiling_set);
 
     oss << "<head>";
     oss << "<script src='http://apps.bdimg.com/libs/jquery/2.1.4/jquery.min.js'></script>";
@@ -429,37 +433,37 @@ std::string Profiling::ShowResult(ProfilingType profiling_type,
     oss << viz_min_js;
     oss << "</script>";
     oss << "<script type=\"text/javascript\">\n";
-    oss << "function onProfChanged(obj) {\n";
+    oss << "function onViewChanged(obj) {\n";
     oss << "  window.location.href = "
         << "'/profiling?' + obj.title + '=page&prof=' + obj.value;\n";
     oss << "}\n";
     oss << "function onDiffChanged(obj) {\n";
-    oss << "  var prof_file = document.getElementById('view_" << prof_type << "').value;";
-    oss << "  window.location.href = " 
-        << "'/profiling?' + obj.title + '=diff&prof=' + prof_file + '&base=' + obj.value;\n";
+    oss << "  var profiling_file = document.getElementById('view_" << profiling_type_str << "').value;";
+    oss << "  window.location.href = "
+        << "'/profiling?' + obj.title + '=diff&prof=' + profiling_file + '&base=' + obj.value;\n";
     oss << "}\n";
     oss << "</script>";
     oss << "</head>";
 
-    oss << "<div><a href='/profiling?" << prof_type 
-        << "=newgraph'>start new " << prof_type << " profiling</a></div>";
+    oss << "<div><a href='/profiling?" << profiling_type_str
+        << "=newgraph'>start new " << profiling_type_str << " profiling</a></div>";
 
-    oss << "<div><a href='/profiling?" << prof_type 
-        << "=cleanup'>remove all " << prof_type << " profiling</a></div>";
+    oss << "<div><a href='/profiling?" << profiling_type_str
+        << "=cleanup'>remove all " << profiling_type_str << " profiling</a></div>";
 
     oss << "<div>exec path:[" << _dir.path << "]</div>";
     oss << "<div>exec binary:[" << _dir.name << "]</div>";
 
     oss << "<p></p>";
     oss << "<pre style='display:inline'>View </pre>";
-    oss << "<select id=view_" << prof_type 
-        << " title=" << prof_type << " onchange='onProfChanged(this)'>";
+    oss << "<select id=view_" << profiling_type_str
+        << " title=" << profiling_type_str << " onchange='onViewChanged(this)'>";
     oss << "<option value=''> profiler file</option>";
-    for (std::set<std::string>::iterator it = prof_files.begin(); 
-            it != prof_files.end(); ++it)
+    for (std::set<std::string>::iterator it = profiling_set.begin();
+            it != profiling_set.end(); ++it)
     {
-        oss << "<option value='" << *it << "' "; 
-        if (prof_file == *it)
+        oss << "<option value='" << *it << "' ";
+        if (profiling_file == *it)
         {
             oss << "selected";
         }
@@ -467,18 +471,18 @@ std::string Profiling::ShowResult(ProfilingType profiling_type,
     }
     oss << "</select>";
     oss << "<pre style='display:inline'>Diff </pre>";
-    oss << "<select id=diff_" << prof_type 
-        << " title=" << prof_type << " onchange='onDiffChanged(this)'>";
+    oss << "<select id=diff_" << profiling_type_str
+        << " title=" << profiling_type_str << " onchange='onDiffChanged(this)'>";
     oss << "<option value=''> profiler file</option>";
-    for (std::set<std::string>::iterator it = prof_files.begin(); 
-            it != prof_files.end(); ++it)
+    for (std::set<std::string>::iterator it = profiling_set.begin();
+            it != profiling_set.end(); ++it)
     {
-        if (prof_file == *it)
+        if (profiling_file == *it)
         {
             continue;
         }
         oss << "<option value='" << *it << "' ";
-        if (prof_base == *it)
+        if (profiling_base == *it)
         {
             oss << "selected";
         }
@@ -488,10 +492,10 @@ std::string Profiling::ShowResult(ProfilingType profiling_type,
 
     oss << "<div id='result'></div>";
     oss << "<script>";
-    oss << "$.ajax({ type:'GET', url:'/profiling?" << prof_type << "=graph&prof=" << prof_file;
-    if (!prof_base.empty())
+    oss << "$.ajax({ type:'GET', url:'/profiling?" << profiling_type_str << "=graph&prof=" << profiling_file;
+    if (!profiling_base.empty())
     {
-        oss << "&base=" << prof_base;
+        oss << "&base=" << profiling_base;
     }
     oss << "', ";
     oss << "success:function(data){";
@@ -502,7 +506,7 @@ std::string Profiling::ShowResult(ProfilingType profiling_type,
     return oss.str();
 }
 
-Profiling::Status Profiling::DoMemoryProfiling(DataType data_type, std::string& prof_file)
+Profiling::Status Profiling::DoMemoryProfiling(DataType data_type, std::string& profiling_file)
 {
     // TODO
     if (HeapProfilerStart == NULL)
@@ -515,12 +519,16 @@ Profiling::Status Profiling::DoMemoryProfiling(DataType data_type, std::string& 
         return PROFILING;
     }
 
-    std::set<std::string> prof_files;
-    ListFile(_dir.path + HEAP_PROFILING_PATH, prof_files);
+    std::set<std::string> profiling_set;
+    ListFile(_dir.path + HEAP_PROFILING_PATH, profiling_set);
 
-    if (prof_file == "default" && !prof_files.empty() && data_type != NEW_GRAPH)
+    if (profiling_file == "default" && !profiling_set.empty() && data_type != NEW_GRAPH)
     {
-        prof_file = *(prof_files.rbegin());
+        profiling_file = *(profiling_set.rbegin());
+        return FINISHED;
+    }
+    if (IsFileExist(_dir.path + HEAP_PROFILING_PATH + profiling_file)) 
+    {
         return FINISHED;
     }
     _is_mem_profiling = true;

--- a/src/sofa/pbrpc/profiling.h
+++ b/src/sofa/pbrpc/profiling.h
@@ -28,7 +28,9 @@ public:
     {
         PAGE = 1,
         GRAPH = 2,
-        NEW_GRAPH = 3
+        NEW_GRAPH = 3,
+        DIFF = 4,
+        CLEANUP = 5
     };
 
     enum Status
@@ -40,11 +42,13 @@ public:
     };
 
     std::string ProfilingPage(ProfilingType profiling_type, 
-                              DataType data_type);
+                              DataType data_type,
+                              std::string& prof_file,
+                              std::string& prof_base);
 
-    Status DoCpuProfiling(DataType data_type);
+    Status DoCpuProfiling(DataType data_type, std::string& prof_file);
 
-    int DoMemoryProfiling();
+    Status DoMemoryProfiling(DataType data_type, std::string& prof_file);
 
     static Profiling* Instance();
 
@@ -59,7 +63,8 @@ private:
 
     void MemoryProfilingFunc();
 
-    std::string ShowResult();
+    std::string ShowResult(ProfilingType profiling_type,
+            const std::string& prof_file, const std::string& prof_base);
 
     static void InitProfiling();
     
@@ -72,7 +77,9 @@ private:
     };
 
 private:
-    volatile bool _is_profiling;
+    volatile bool _is_cpu_profiling;
+
+    volatile bool _is_mem_profiling;
 
     volatile bool _is_initialized;
 

--- a/src/sofa/pbrpc/profiling.h
+++ b/src/sofa/pbrpc/profiling.h
@@ -43,12 +43,12 @@ public:
 
     std::string ProfilingPage(ProfilingType profiling_type, 
                               DataType data_type,
-                              std::string& prof_file,
-                              std::string& prof_base);
+                              std::string& profiling_file,
+                              std::string& profiling_base);
 
-    Status DoCpuProfiling(DataType data_type, std::string& prof_file);
+    Status DoCpuProfiling(DataType data_type, std::string& profiling_file);
 
-    Status DoMemoryProfiling(DataType data_type, std::string& prof_file);
+    Status DoMemoryProfiling(DataType data_type, std::string& profiling_file);
 
     static Profiling* Instance();
 
@@ -64,7 +64,7 @@ private:
     void MemoryProfilingFunc();
 
     std::string ShowResult(ProfilingType profiling_type,
-            const std::string& prof_file, const std::string& prof_base);
+            const std::string& profiling_file, const std::string& profiling_base);
 
     static void InitProfiling();
     

--- a/src/sofa/pbrpc/profiling_linker.h
+++ b/src/sofa/pbrpc/profiling_linker.h
@@ -1,13 +1,10 @@
 #ifndef SOFA_PBRPC_PROFILING_LINKER_H
 #define SOFA_PBRPC_PROFILING_LINKER_H
 
-#if defined(SOFA_PBRPC_CPU_PROFILING)
+#if defined(SOFA_PBRPC_PROFILING)
 #include <gperftools/profiler.h>
-#endif // SOFA_PBRPC_CPU_PROFILING
-
-#if defined(SOFA_PBRPC_HEAP_PROFILING)
-#include <gperftools/heap-profiler.h>
-#endif // SOFA_PBRPC_HEAP_PROFILING
+void TCMallocGetHeapSample(std::string* writer);
+#endif // SOFA_PBRPC_PROFILING
 
 extern bool PROFILING_LINKER_FALSE;
 
@@ -19,13 +16,10 @@ public:
         // make libprofiler be linked
         if (PROFILING_LINKER_FALSE != false)
         {
-#if defined(SOFA_PBRPC_CPU_PROFILING)
+#if defined(SOFA_PBRPC_PROFILING)
             ProfilerStart(NULL);
-#endif // SOFA_PBRPC_CPU_PROFILING
-
-#if defined(SOFA_PBRPC_HEAP_PROFILING)
-            HeapProfilerStart(NULL);
-#endif // SOFA_PBRPC_HEAP_PROFILING
+            TCMallocGetHeapSample(NULL);
+#endif // SOFA_PBRPC_PROFILING
         }
     }
 };

--- a/src/sofa/pbrpc/profiling_linker.h
+++ b/src/sofa/pbrpc/profiling_linker.h
@@ -1,19 +1,32 @@
 #ifndef SOFA_PBRPC_PROFILING_LINKER_H
 #define SOFA_PBRPC_PROFILING_LINKER_H
 
-#if defined(SOFA_PBRPC_PROFILING)
+#if defined(SOFA_PBRPC_CPU_PROFILING)
 #include <gperftools/profiler.h>
-#endif // SOFA_PBRPC_PROFILING
+#endif // SOFA_PBRPC_CPU_PROFILING
+
+#if defined(SOFA_PBRPC_HEAP_PROFILING)
+#include <gperftools/heap-profiler.h>
+#endif // SOFA_PBRPC_HEAP_PROFILING
+
+extern bool PROFILING_LINKER_FALSE;
 
 class ProfilingLinker
 {
 public:
     ProfilingLinker()
     {
-#if defined(SOFA_PBRPC_PROFILING)
         // make libprofiler be linked
-        (void)ProfilingIsEnabledForAllThreads();
-#endif // SOFA_PBRPC_PROFILING
+        if (PROFILING_LINKER_FALSE != false)
+        {
+#if defined(SOFA_PBRPC_CPU_PROFILING)
+            ProfilerStart(NULL);
+#endif // SOFA_PBRPC_CPU_PROFILING
+
+#if defined(SOFA_PBRPC_HEAP_PROFILING)
+            HeapProfilerStart(NULL);
+#endif // SOFA_PBRPC_HEAP_PROFILING
+        }
     }
 };
 

--- a/src/sofa/pbrpc/tcmalloc_extension_helper.cc
+++ b/src/sofa/pbrpc/tcmalloc_extension_helper.cc
@@ -1,0 +1,321 @@
+// This file pastes google/malloc_extension.h and implements
+// TCMallocGetHeapSample in the last sections.
+
+// Copyright (c) 2005, Google Inc.
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+// 
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// ---
+// Author: Sanjay Ghemawat <opensource@google.com>
+//
+// Extra extensions exported by some malloc implementations.  These
+// extensions are accessed through a virtual base class so an
+// application can link against a malloc that does not implement these
+// extensions, and it will get default versions that do nothing.
+//
+// NOTE FOR C USERS: If you wish to use this functionality from within
+// a C program, see malloc_extension_c.h.
+
+#include <stddef.h>
+// I can't #include config.h in this public API file, but I should
+// really use configure (and make malloc_extension.h a .in file) to
+// figure out if the system has stdint.h or not.  But I'm lazy, so
+// for now I'm assuming it's a problem only with MSVC.
+#ifndef _MSC_VER
+#include <stdint.h>
+#endif
+#include <string>
+#include <vector>
+
+// Annoying stuff for windows -- makes sure clients can import these functions
+#ifndef PERFTOOLS_DLL_DECL
+# ifdef _WIN32
+#   define PERFTOOLS_DLL_DECL  __declspec(dllimport)
+# else
+#   define PERFTOOLS_DLL_DECL
+# endif
+#endif
+
+static const int kMallocHistogramSize = 64;
+
+typedef std::string MallocExtensionWriter;
+
+namespace base {
+struct MallocRange;
+}
+
+// The default implementations of the following routines do nothing.
+// All implementations should be thread-safe; the current one
+// (TCMallocImplementation) is.
+class PERFTOOLS_DLL_DECL MallocExtension {
+ public:
+  virtual ~MallocExtension();
+
+  // Call this very early in the program execution -- say, in a global
+  // constructor -- to set up parameters and state needed by all
+  // instrumented malloc implemenatations.  One example: this routine
+  // sets environemnt variables to tell STL to use libc's malloc()
+  // instead of doing its own memory management.  This is safe to call
+  // multiple times, as long as each time is before threads start up.
+  static void Initialize();
+
+  // See "verify_memory.h" to see what these routines do
+  virtual bool VerifyAllMemory();
+  virtual bool VerifyNewMemory(void* p);
+  virtual bool VerifyArrayNewMemory(void* p);
+  virtual bool VerifyMallocMemory(void* p);
+  virtual bool MallocMemoryStats(int* blocks, size_t* total,
+                                 int histogram[kMallocHistogramSize]);
+
+  // Get a human readable description of the current state of the malloc
+  // data structures.  The state is stored as a null-terminated string
+  // in a prefix of "buffer[0,buffer_length-1]".
+  // REQUIRES: buffer_length > 0.
+  virtual void GetStats(char* buffer, int buffer_length);
+
+  // Outputs to "writer" a sample of live objects and the stack traces
+  // that allocated these objects.  The format of the returned output
+  // is equivalent to the output of the heap profiler and can
+  // therefore be passed to "pprof".
+  // NOTE: by default, tcmalloc does not do any heap sampling, and this
+  //       function will always return an empty sample.  To get useful
+  //       data from GetHeapSample, you must also set the environment
+  //       variable TCMALLOC_SAMPLE_PARAMETER to a value such as 524288.
+  virtual void GetHeapSample(MallocExtensionWriter* writer);
+
+  // Outputs to "writer" the stack traces that caused growth in the
+  // address space size.  The format of the returned output is
+  // equivalent to the output of the heap profiler and can therefore
+  // be passed to "pprof".  (This does not depend on, or require,
+  // TCMALLOC_SAMPLE_PARAMETER.)
+  virtual void GetHeapGrowthStacks(MallocExtensionWriter* writer);
+
+  // Invokes func(arg, range) for every controlled memory
+  // range.  *range is filled in with information about the range.
+  //
+  // This is a best-effort interface useful only for performance
+  // analysis.  The implementation may not call func at all.
+  typedef void (RangeFunction)(void*, const base::MallocRange*);
+  virtual void Ranges(void* arg, RangeFunction func);
+
+  // -------------------------------------------------------------------
+  // Control operations for getting and setting malloc implementation
+  // specific parameters.  Some currently useful properties:
+  //
+  // generic
+  // -------
+  // "generic.current_allocated_bytes"
+  //      Number of bytes currently allocated by application
+  //      This property is not writable.
+  //
+  // "generic.heap_size"
+  //      Number of bytes in the heap ==
+  //            current_allocated_bytes +
+  //            fragmentation +
+  //            freed memory regions
+  //      This property is not writable.
+  //
+  // tcmalloc
+  // --------
+  // "tcmalloc.max_total_thread_cache_bytes"
+  //      Upper limit on total number of bytes stored across all
+  //      per-thread caches.  Default: 16MB.
+  //
+  // "tcmalloc.current_total_thread_cache_bytes"
+  //      Number of bytes used across all thread caches.
+  //      This property is not writable.
+  //
+  // "tcmalloc.pageheap_free_bytes"
+  //      Number of bytes in free, mapped pages in page heap.  These
+  //      bytes can be used to fulfill allocation requests.  They
+  //      always count towards virtual memory usage, and unless the
+  //      underlying memory is swapped out by the OS, they also count
+  //      towards physical memory usage.  This property is not writable.
+  //
+  // "tcmalloc.pageheap_unmapped_bytes"
+  //        Number of bytes in free, unmapped pages in page heap.
+  //        These are bytes that have been released back to the OS,
+  //        possibly by one of the MallocExtension "Release" calls.
+  //        They can be used to fulfill allocation requests, but
+  //        typically incur a page fault.  They always count towards
+  //        virtual memory usage, and depending on the OS, typically
+  //        do not count towards physical memory usage.  This property
+  //        is not writable.
+  // -------------------------------------------------------------------
+
+  // Get the named "property"'s value.  Returns true if the property
+  // is known.  Returns false if the property is not a valid property
+  // name for the current malloc implementation.
+  // REQUIRES: property != NULL; value != NULL
+  virtual bool GetNumericProperty(const char* property, size_t* value);
+
+  // Set the named "property"'s value.  Returns true if the property
+  // is known and writable.  Returns false if the property is not a
+  // valid property name for the current malloc implementation, or
+  // is not writable.
+  // REQUIRES: property != NULL
+  virtual bool SetNumericProperty(const char* property, size_t value);
+
+  // Mark the current thread as "idle".  This routine may optionally
+  // be called by threads as a hint to the malloc implementation that
+  // any thread-specific resources should be released.  Note: this may
+  // be an expensive routine, so it should not be called too often.
+  //
+  // Also, if the code that calls this routine will go to sleep for
+  // a while, it should take care to not allocate anything between
+  // the call to this routine and the beginning of the sleep.
+  //
+  // Most malloc implementations ignore this routine.
+  virtual void MarkThreadIdle();
+
+  // Mark the current thread as "busy".  This routine should be
+  // called after MarkThreadIdle() if the thread will now do more
+  // work.  If this method is not called, performance may suffer.
+  //
+  // Most malloc implementations ignore this routine.
+  virtual void MarkThreadBusy();
+
+  // Try to release num_bytes of free memory back to the operating
+  // system for reuse.  Use this extension with caution -- to get this
+  // memory back may require faulting pages back in by the OS, and
+  // that may be slow.  (Currently only implemented in tcmalloc.)
+  virtual void ReleaseToSystem(size_t num_bytes);
+
+  // Same as ReleaseToSystem() but release as much memory as possible.
+  virtual void ReleaseFreeMemory();
+
+  // Sets the rate at which we release unused memory to the system.
+  // Zero means we never release memory back to the system.  Increase
+  // this flag to return memory faster; decrease it to return memory
+  // slower.  Reasonable rates are in the range [0,10].  (Currently
+  // only implemented in tcmalloc).
+  virtual void SetMemoryReleaseRate(double rate);
+
+  // Gets the release rate.  Returns a value < 0 if unknown.
+  virtual double GetMemoryReleaseRate();
+
+  // Returns the estimated number of bytes that will be allocated for
+  // a request of "size" bytes.  This is an estimate: an allocation of
+  // SIZE bytes may reserve more bytes, but will never reserve less.
+  // (Currently only implemented in tcmalloc, other implementations
+  // always return SIZE.)
+  // This is equivalent to malloc_good_size() in OS X.
+  virtual size_t GetEstimatedAllocatedSize(size_t size);
+
+  // Returns the actual number N of bytes reserved by tcmalloc for the
+  // pointer p.  The client is allowed to use the range of bytes
+  // [p, p+N) in any way it wishes (i.e. N is the "usable size" of this
+  // allocation).  This number may be equal to or greater than the number
+  // of bytes requested when p was allocated.
+  // p must have been allocated by this malloc implementation,
+  // must not be an interior pointer -- that is, must be exactly
+  // the pointer returned to by malloc() et al., not some offset
+  // from that -- and should not have been freed yet.  p may be NULL.
+  // (Currently only implemented in tcmalloc; other implementations
+  // will return 0.)
+  // This is equivalent to malloc_size() in OS X, malloc_usable_size()
+  // in glibc, and _msize() for windows.
+  virtual size_t GetAllocatedSize(void* p);
+
+  // The current malloc implementation.  Always non-NULL.
+  static MallocExtension* instance();
+
+  // Change the malloc implementation.  Typically called by the
+  // malloc implementation during initialization.
+  static void Register(MallocExtension* implementation);
+
+  // Returns detailed information about malloc's freelists. For each list,
+  // return a FreeListInfo:
+  struct FreeListInfo {
+    size_t min_object_size;
+    size_t max_object_size;
+    size_t total_bytes_free;
+    const char* type;
+  };
+  // Each item in the vector refers to a different freelist. The lists
+  // are identified by the range of allocations that objects in the
+  // list can satisfy ([min_object_size, max_object_size]) and the
+  // type of freelist (see below). The current size of the list is
+  // returned in total_bytes_free (which count against a processes
+  // resident and virtual size).
+  //
+  // Currently supported types are:
+  //
+  // "tcmalloc.page{_unmapped}" - tcmalloc's page heap. An entry for each size
+  //          class in the page heap is returned. Bytes in "page_unmapped"
+  //          are no longer backed by physical memory and do not count against
+  //          the resident size of a process.
+  //
+  // "tcmalloc.large{_unmapped}" - tcmalloc's list of objects larger
+  //          than the largest page heap size class. Only one "large"
+  //          entry is returned. There is no upper-bound on the size
+  //          of objects in the large free list; this call returns
+  //          kint64max for max_object_size.  Bytes in
+  //          "large_unmapped" are no longer backed by physical memory
+  //          and do not count against the resident size of a process.
+  //
+  // "tcmalloc.central" - tcmalloc's central free-list. One entry per
+  //          size-class is returned. Never unmapped.
+  //
+  // "debug.free_queue" - free objects queued by the debug allocator
+  //                      and not returned to tcmalloc.
+  //
+  // "tcmalloc.thread" - tcmalloc's per-thread caches. Never unmapped.
+  virtual void GetFreeListSizes(std::vector<FreeListInfo>* v);
+
+ protected:
+  // Get a list of stack traces of sampled allocation points.  Returns
+  // a pointer to a "new[]-ed" result array, and stores the sample
+  // period in "sample_period".
+  //
+  // The state is stored as a sequence of adjacent entries
+  // in the returned array.  Each entry has the following form:
+  //    uintptr_t count;        // Number of objects with following trace
+  //    uintptr_t size;         // Total size of objects with following trace
+  //    uintptr_t depth;        // Number of PC values in stack trace
+  //    void*     stack[depth]; // PC values that form the stack trace
+  //
+  // The list of entries is terminated by a "count" of 0.
+  //
+  // It is the responsibility of the caller to "delete[]" the returned array.
+  //
+  // May return NULL to indicate no results.
+  //
+  // This is an internal extension.  Callers should use the more
+  // convenient "GetHeapSample(string*)" method defined above.
+  virtual void** ReadStackTraces(int* sample_period);
+
+  // Like ReadStackTraces(), but returns stack traces that caused growth
+  // in the address space size.
+  virtual void** ReadHeapGrowthStackTraces();
+};
+
+void TCMallocGetHeapSample(std::string* writer) {
+    MallocExtension::instance()->GetHeapSample(writer);
+}
+

--- a/src/sofa/pbrpc/web_service.cc
+++ b/src/sofa/pbrpc/web_service.cc
@@ -376,13 +376,12 @@ bool WebService::DefaultProfiling(const HTTPRequest& request,
     Profiling::ProfilingType profiling_type = Profiling::DEFAULT;
     Profiling::DataType data_type = Profiling::PAGE;
 
-    std::string prof_file;
-    std::string prof_base;
+    std::string profiling_file;
+    std::string profiling_base;
 
     QueryParams::const_iterator it = query_params->find("cpu");
     if (it != query_params->end())
     {
-        
         profiling_type = Profiling::CPU;
     }
     else
@@ -420,20 +419,21 @@ bool WebService::DefaultProfiling(const HTTPRequest& request,
     it = query_params->find("prof");
     if (it != query_params->end())
     {
-        prof_file = it->second;
+        profiling_file = it->second;
     }
     else
     {
-        prof_file = "default";
+        profiling_file = "default";
     }
     it = query_params->find("base");
     if (it != query_params->end())
     {
-        prof_base = it->second;
+        profiling_base = it->second;
     }
 
     Profiling* instance = Profiling::Instance();
-    return response.content->Append(instance->ProfilingPage(profiling_type, data_type, prof_file, prof_base));
+    return response.content->Append(instance->ProfilingPage(
+                profiling_type, data_type, profiling_file, profiling_base));
 }
 
 void WebService::PageHeader(std::ostream& out)

--- a/src/sofa/pbrpc/web_service.cc
+++ b/src/sofa/pbrpc/web_service.cc
@@ -376,6 +376,9 @@ bool WebService::DefaultProfiling(const HTTPRequest& request,
     Profiling::ProfilingType profiling_type = Profiling::DEFAULT;
     Profiling::DataType data_type = Profiling::PAGE;
 
+    std::string prof_file;
+    std::string prof_base;
+
     QueryParams::const_iterator it = query_params->find("cpu");
     if (it != query_params->end())
     {
@@ -400,14 +403,37 @@ bool WebService::DefaultProfiling(const HTTPRequest& request,
         {
             data_type = Profiling::NEW_GRAPH;
         }
+        else if (it->second == "diff")
+        {
+            data_type = Profiling::DIFF;
+        }
+        else if (it->second == "cleanup")
+        {
+            data_type = Profiling::CLEANUP;
+        }
         else
         {
             data_type = Profiling::PAGE;
         }
     }
 
+    it = query_params->find("prof");
+    if (it != query_params->end())
+    {
+        prof_file = it->second;
+    }
+    else
+    {
+        prof_file = "default";
+    }
+    it = query_params->find("base");
+    if (it != query_params->end())
+    {
+        prof_base = it->second;
+    }
+
     Profiling* instance = Profiling::Instance();
-    return response.content->Append(instance->ProfilingPage(profiling_type, data_type));
+    return response.content->Append(instance->ProfilingPage(profiling_type, data_type, prof_file, prof_base));
 }
 
 void WebService::PageHeader(std::ostream& out)


### PR DESCRIPTION
# 功能
当前rpc已经支持cpu的profiling[#64](https://github.com/baidu/sofa-pbrpc/issues/64)，现增加内存的profiling，通过对内存使用的采样方便用户分析。

# 设计细节
1. 处理流程与cpu profiling保持一致。
2. 封装 tcmalloc中的MallocExtension::instance()->GetHeapSample(writer);对内存使用进行采样。
3. 使用弱符号引入TCMallocGetHeapSample，保证在用户联编tcmalloc后方可使用。
4. 方便用户对两次结果进行diff,增加两次采样的diff
5. 提供删除按钮，用户可以删除采样数据

@cyshi @qinzuoyan @bluebore 请大家给些意见，谢谢！