### PR TITLE
Fix message_header overflow

### DIFF
--- a/src/sofa/pbrpc/binary_rpc_request_parser.cc
+++ b/src/sofa/pbrpc/binary_rpc_request_parser.cc
@@ -7,6 +7,10 @@
 namespace sofa {
 namespace pbrpc {
 
+#define SOFA_PBRPC_MAX_RPC_MESSAGE_SIZE (64 << 20) 
+const int64 BinaryRpcRequestParser::MAX_MESSAGE_SIZE = 
+    SOFA_PBRPC_MAX_RPC_MESSAGE_SIZE + sizeof(RpcMessageHeader);
+
 BinaryRpcRequestParser::BinaryRpcRequestParser() :
     _state(PS_MAGIC_STRING),
     _bytes_recved(0),
@@ -51,12 +55,12 @@ int BinaryRpcRequestParser::Parse(const char* buf,
         return 0;
     }
     *bytes_consumed = 0;
-    int bytes_remain, consume;
+    int64 bytes_remain, consume;
     switch (_state)
     {
         case PS_MSG_HEADER:
             bytes_remain = sizeof(RpcMessageHeader) - _bytes_recved;
-            consume = std::min(data_size, bytes_remain);
+            consume = std::min(static_cast<int64>(data_size), bytes_remain);
             memcpy(reinterpret_cast<char*>(&_req->_req_header) + _bytes_recved,
                     buf + offset, consume);
             *bytes_consumed += consume;
@@ -82,7 +86,21 @@ int BinaryRpcRequestParser::Parse(const char* buf,
             }
         case PS_MSG_BODY:
             bytes_remain = _req->_req_header.message_size - _bytes_recved;
-            consume = std::min(data_size, bytes_remain);
+            if (bytes_remain >= MAX_MESSAGE_SIZE)
+            {
+                // rpc message size is too large
+#if defined( LOG )
+                LOG(ERROR) << "Parse(): " << RpcEndpointToString(_req->_remote_endpoint)
+                           << ": message size[" << bytes_remain 
+                           << "] exceed the limit[" << MAX_MESSAGE_SIZE << "]";
+#else
+                SLOG(ERROR, "Parse(): %s: message size[%lld] exceed the limit[%lld]",
+                     RpcEndpointToString(_req->_remote_endpoint).c_str(), 
+                     bytes_remain, MAX_MESSAGE_SIZE);
+#endif
+                return -1;
+            }
+            consume = std::min(static_cast<int64>(data_size), bytes_remain);
             _req->_req_body->Append(BufHandle(const_cast<char*>(buf), consume, offset));
             *bytes_consumed += consume;
             _bytes_recved += consume;

--- a/src/sofa/pbrpc/binary_rpc_request_parser.cc
+++ b/src/sofa/pbrpc/binary_rpc_request_parser.cc
@@ -86,15 +86,15 @@ int BinaryRpcRequestParser::Parse(const char* buf,
             }
         case PS_MSG_BODY:
             bytes_remain = _req->_req_header.message_size - _bytes_recved;
-            if (bytes_remain > MAX_MESSAGE_SIZE)
+            if (bytes_remain > MAX_MESSAGE_SIZE || bytes_remain <= 0)
             {
-                // rpc message size is too large
+                // compute bytes_remain error
 #if defined( LOG )
                 LOG(ERROR) << "Parse(): " << RpcEndpointToString(_req->_remote_endpoint)
-                           << ": message size[" << bytes_remain 
-                           << "] exceed the limit[" << MAX_MESSAGE_SIZE << "]";
+                           << ": compute bytes_remain[" << bytes_remain
+                           << "] error, message size limit[" << MAX_MESSAGE_SIZE << "]";
 #else
-                SLOG(ERROR, "Parse(): %s: message size[%lld] exceed the limit[%lld]",
+                SLOG(ERROR, "Parse(): %s: compute bytes_remain[%lld] error, message size limit[%lld]",
                      RpcEndpointToString(_req->_remote_endpoint).c_str(), 
                      bytes_remain, MAX_MESSAGE_SIZE);
 #endif

--- a/src/sofa/pbrpc/binary_rpc_request_parser.cc
+++ b/src/sofa/pbrpc/binary_rpc_request_parser.cc
@@ -86,7 +86,7 @@ int BinaryRpcRequestParser::Parse(const char* buf,
             }
         case PS_MSG_BODY:
             bytes_remain = _req->_req_header.message_size - _bytes_recved;
-            if (bytes_remain >= MAX_MESSAGE_SIZE)
+            if (bytes_remain > MAX_MESSAGE_SIZE)
             {
                 // rpc message size is too large
 #if defined( LOG )

--- a/src/sofa/pbrpc/binary_rpc_request_parser.h
+++ b/src/sofa/pbrpc/binary_rpc_request_parser.h
@@ -37,6 +37,8 @@ private:
     ParseState _state; // current parsing state
     int _bytes_recved; // bytes received in current state
     BinaryRpcRequestPtr _req;
+
+    static const int64 MAX_MESSAGE_SIZE;
 }; // class BinaryRpcRequestParser
 
 } // namespace pbrpc


### PR DESCRIPTION
RpcMessageHeader 中 message_size 是 int64

在计算 bytes_remain 的时候 使用的是int

所以 如果用户恶意的传入包头参数 可能导致rpc做buffer检查的时候触发assert