### PR TITLE
support user defined compiler through CXX env variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,9 +73,12 @@ else
     endif
 endif
 
+ifndef CXX
+    CXX=g++
+endif
+
 #-----------------------------------------------
 
-CXX=g++
 INCPATH=-Isrc -I$(BOOST_HEADER_DIR) -I$(PROTOBUF_DIR)/include -I$(SNAPPY_DIR)/include -I$(ZLIB_DIR)/include
 CXXFLAGS += $(OPT) -pipe -W -Wall -fPIC -D_GNU_SOURCE -D__STDC_LIMIT_MACROS -DHAVE_SNAPPY $(INCPATH)
 


### PR DESCRIPTION
if there are more than one compilers on system :
/usr/bin/g++
/usr/bin/g++-4.8
and the users want to compile sofa-pbrpc with g++-4.8, they can do it in this way: 
CXX=g++-4.8 make