### PR TITLE
Add create_with_init option in RpcChannelOptions

### DIFF
--- a/src/sofa/pbrpc/rpc_channel.cc
+++ b/src/sofa/pbrpc/rpc_channel.cc
@@ -16,7 +16,10 @@ RpcChannel::RpcChannel(RpcClient* rpc_client,
         const RpcChannelOptions& options)
     : _impl(new SimpleRpcChannelImpl(rpc_client->impl(), server_address, options))
 {
-    _impl->Init();
+    if (options.create_with_init)
+    {
+        _impl->Init();
+    }
 }
 
 RpcChannel::RpcChannel(RpcClient* rpc_client,
@@ -27,7 +30,10 @@ RpcChannel::RpcChannel(RpcClient* rpc_client,
     std::ostringstream os;
     os << server_ip << ":" << server_port;
     _impl.reset(new SimpleRpcChannelImpl(rpc_client->impl(), os.str(), options));
-    _impl->Init();
+    if (options.create_with_init)
+    {
+        _impl->Init();
+    }
 }
 
 RpcChannel::RpcChannel(RpcClient* rpc_client,
@@ -35,7 +41,10 @@ RpcChannel::RpcChannel(RpcClient* rpc_client,
         const RpcChannelOptions& options)
     : _impl(new DynamicRpcChannelImpl(rpc_client->impl(), address_list, options))
 {
-    _impl->Init();
+    if (options.create_with_init)
+    {
+        _impl->Init();
+    }
 }
 
 RpcChannel::RpcChannel(RpcClient* rpc_client,
@@ -43,7 +52,15 @@ RpcChannel::RpcChannel(RpcClient* rpc_client,
         const RpcChannelOptions& options)
     : _impl(new DynamicRpcChannelImpl(rpc_client->impl(), address_provider, options))
 {
-    _impl->Init();
+    if (options.create_with_init)
+    {
+        _impl->Init();
+    }
+}
+
+bool RpcChannel::Init()
+{
+    return _impl->Init();
 }
 
 RpcChannel::~RpcChannel()

--- a/src/sofa/pbrpc/rpc_channel.h
+++ b/src/sofa/pbrpc/rpc_channel.h
@@ -32,9 +32,14 @@ struct RpcChannelOptions {
     // Value 0 means no limit, default value is 0.
     uint32 server_load_capacity;
 
+    // If initialize the RpcChannel in construct function, default is true.
+    // If create_with_init is false, RpcChannel should be initialized by calling Init().
+    bool create_with_init;
+
     RpcChannelOptions()
         : connect_timeout(10)
         , server_load_capacity(0)
+        , create_with_init(true)
     {}
 };
 
@@ -92,6 +97,14 @@ public:
     RpcChannel(RpcClient* rpc_client,
                AddressProvider* address_provider,
                const RpcChannelOptions& options = RpcChannelOptions());
+
+    // Initialize RpcChannel.
+    // For single server point, it will resolve server address in this function,
+    // and if resolve server address succeed return true, otherwise return false.
+    // For multiple server points, it will update internal server list and
+    // register detect task. After all of these are completed return true, and
+    // never return false.
+    bool Init();
 
     // Destructor.
     virtual ~RpcChannel();


### PR DESCRIPTION
同步master中RpcChannelOptions增加create_with_init选项的升级，详情见[104](https://github.com/baidu/sofa-pbrpc/issues/104)