### PR TITLE
Update dynamic_rpc_channel_impl.cc

### DIFF
--- a/src/sofa/pbrpc/dynamic_rpc_channel_impl.cc
+++ b/src/sofa/pbrpc/dynamic_rpc_channel_impl.cc
@@ -652,6 +652,7 @@ bool DynamicRpcChannelImpl::ServerContext::InitBuiltinService(const RpcChannelOp
         // double check
         return true;
     }
+    ScopedLocker<LockType> _auto_ref(channel_init_lock);
     if (!channel) {
         // no channel available
         return false;


### PR DESCRIPTION
保护 channel 有效性。 解决 iplist 配置错误导致的 server->builtin_service在 Health方法中使用 channel 野指针导致的 core