### PR TITLE
Add loongarch support

### DIFF
--- a/sp_counted_base_gcc_loongarch64.hpp
+++ b/sp_counted_base_gcc_loongarch64.hpp
@@ -1,0 +1,155 @@
+// Copyright (c) 2014 Baidu.com, Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+//
+// Author: qinzuoyan01@baidu.com (Qin Zuoyan)
+
+// This file is modified from boost.
+//
+// Copyright Beman Dawes 2002, 2006
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// See library home page at http://www.boost.org/libs/system
+
+#ifndef _SOFA_PBRPC_SMART_PTR_DETAIL_SP_COUNTED_BASE_GCC_LOONGARCH64_
+#define _SOFA_PBRPC_SMART_PTR_DETAIL_SP_COUNTED_BASE_GCC_LOONGARCH64_
+
+#include <typeinfo>
+#include <iostream>
+namespace sofa {
+namespace pbrpc {
+namespace detail {
+
+inline int atomic_exchange_and_add( int * pw, int dv )
+{
+    // int r = *pw;
+    // *pw += dv;
+    // return r;
+
+
+    int r ;
+    __asm__ __volatile__
+    (
+       "ll.w $r12, %0\n\t"
+       "add.w %2, $r0, $r12\n\t"
+       "sc.w $r12, %0\n\t"
+       "ll.w $r12, %0\n\t"
+       "add.w $r12, $r12, %1\n\t"
+       "sc.w $r12, %0"
+       :"+m"( *pw ), "+r"( dv ), "+r"(r)
+       ::"memory", "cc", "$r12"
+    );
+    return r;
+}
+
+inline void atomic_increment( int * pw )
+{
+  atomic_exchange_and_add( pw, 1 );
+}
+
+inline int atomic_conditional_increment( int * pw )
+{
+    // int rv = *pw;
+    // if( rv != 0 ) ++*pw;
+    // return rv;
+
+    int rv, tmp;
+    asm(
+                      "ll.w $r12, %0\n\t"
+                      "add.w %1, $r0, $r12\n\t"
+                      "sc.w $r12, %0\n\t"
+                      : "+m"(*pw), "+r"(rv)
+                      :: "cc", "$r12"
+                      );
+    asm(
+		      "ll.w $r12, %0\n\t"
+		      "beqz %1, L\n\t"
+		      "addi.w $r12, $r12, 1\n\t"
+		      "sc.w $r12, %0\n\t"
+		      "L:nop\n\t"
+		      : "+m"(*pw), "+r"(rv), "+r"(tmp)
+		      :: "cc", "$r12"
+		      );
+    return rv;
+}
+
+class sp_counted_base
+{
+private:
+
+    sp_counted_base( sp_counted_base const & );
+    sp_counted_base & operator= ( sp_counted_base const & );
+
+    int use_count_;        // #shared
+    int weak_count_;       // #weak + (#shared != 0)
+
+public:
+
+    sp_counted_base(): use_count_( 1 ), weak_count_( 1 )
+    {
+    }
+
+    virtual ~sp_counted_base() // nothrow
+    {
+    }
+
+    // dispose() is called when use_count_ drops to zero, to release
+    // the resources managed by *this.
+
+    virtual void dispose() = 0; // nothrow
+
+    // destroy() is called when weak_count_ drops to zero.
+
+    virtual void destroy() // nothrow
+    {
+        delete this;
+    }
+
+    virtual void * get_deleter( std::type_info const & ti ) = 0;
+
+    void add_ref_copy()
+    {
+	atomic_increment( &use_count_ );
+    }
+
+    bool add_ref_lock() // true on success
+    {
+        return atomic_conditional_increment( &use_count_ ) != 0;
+    }
+
+    void release() // nothrow
+    {
+        if( atomic_exchange_and_add( &use_count_, -1 ) == 1 )
+        {
+            dispose();
+            weak_release();
+        }
+    }
+
+    void weak_add_ref() // nothrow
+    {
+        atomic_increment( &weak_count_ );
+    }
+
+    void weak_release() // nothrow
+    {
+        if( atomic_exchange_and_add( &weak_count_, -1 ) == 1 )
+        {
+            destroy();
+        }
+    }
+
+    long use_count() const // nothrow
+    {
+        return static_cast<int const volatile &>( use_count_ );
+    }
+};
+
+} // namespace detail
+} // namespace pbrpc
+} // namespace sofa
+
+#endif _SOFA_PBRPC_SMART_PTR_DETAIL_SP_COUNTED_BASE_GCC_LOONGARCH64_
+
+/* vim: set ts=4 sw=4 sts=4 tw=100 */

--- a/src/rapidjson/reader.h
+++ b/src/rapidjson/reader.h
@@ -9,11 +9,11 @@
 #include "internal/stack.h"
 #include <csetjmp>
 
-#ifdef RAPIDJSON_SSE42
-#include <nmmintrin.h>
-#elif defined(RAPIDJSON_SSE2)
-#include <emmintrin.h>
-#endif
+//#ifdef RAPIDJSON_SSE42
+//#include <nmmintrin.h>
+//#elif defined(RAPIDJSON_SSE2)
+//#include <emmintrin.h>
+//#endif
 
 #ifdef _MSC_VER
 #pragma warning(push)
@@ -105,80 +105,80 @@ void SkipWhitespace(Stream& stream) {
 	stream = s;
 }
 
-#ifdef RAPIDJSON_SSE42
+//#ifdef RAPIDJSON_SSE42
 //! Skip whitespace with SSE 4.2 pcmpistrm instruction, testing 16 8-byte characters at once.
-inline const char *SkipWhitespace_SIMD(const char* p) {
-	static const char whitespace[16] = " \n\r\t";
-	__m128i w = _mm_loadu_si128((const __m128i *)&whitespace[0]);
+//inline const char *SkipWhitespace_SIMD(const char* p) {
+//	static const char whitespace[16] = " \n\r\t";
+//	__m128i w = _mm_loadu_si128((const __m128i *)&whitespace[0]);
+//
+//	for (;;) {
+//		__m128i s = _mm_loadu_si128((const __m128i *)p);
+//		unsigned r = _mm_cvtsi128_si32(_mm_cmpistrm(w, s, _SIDD_UBYTE_OPS | _SIDD_CMP_EQUAL_ANY | _SIDD_BIT_MASK | _SIDD_NEGATIVE_POLARITY));
+//		if (r == 0)	// all 16 characters are whitespace
+//			p += 16;
+//		else {		// some of characters may be non-whitespace
+//#ifdef _MSC_VER		// Find the index of first non-whitespace
+//			unsigned long offset;
+//			if (_BitScanForward(&offset, r))
+//				return p + offset;
+//#else
+//			if (r != 0)
+//				return p + __builtin_ffs(r) - 1;
+//#endif
+//		}
+//	}
+//}
 
-	for (;;) {
-		__m128i s = _mm_loadu_si128((const __m128i *)p);
-		unsigned r = _mm_cvtsi128_si32(_mm_cmpistrm(w, s, _SIDD_UBYTE_OPS | _SIDD_CMP_EQUAL_ANY | _SIDD_BIT_MASK | _SIDD_NEGATIVE_POLARITY));
-		if (r == 0)	// all 16 characters are whitespace
-			p += 16;
-		else {		// some of characters may be non-whitespace
-#ifdef _MSC_VER		// Find the index of first non-whitespace
-			unsigned long offset;
-			if (_BitScanForward(&offset, r))
-				return p + offset;
-#else
-			if (r != 0)
-				return p + __builtin_ffs(r) - 1;
-#endif
-		}
-	}
-}
-
-#elif defined(RAPIDJSON_SSE2)
+//#elif defined(RAPIDJSON_SSE2)
 
 //! Skip whitespace with SSE2 instructions, testing 16 8-byte characters at once.
-inline const char *SkipWhitespace_SIMD(const char* p) {
-	static const char whitespaces[4][17] = {
-		"                ",
-		"\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n",
-		"\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r",
-		"\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t"};
+//inline const char *SkipWhitespace_SIMD(const char* p) {
+//	static const char whitespaces[4][17] = {
+//		"                ",
+//		"\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n",
+//		"\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r",
+//		"\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t"};
 
-	__m128i w0 = _mm_loadu_si128((const __m128i *)&whitespaces[0][0]);
-	__m128i w1 = _mm_loadu_si128((const __m128i *)&whitespaces[1][0]);
-	__m128i w2 = _mm_loadu_si128((const __m128i *)&whitespaces[2][0]);
-	__m128i w3 = _mm_loadu_si128((const __m128i *)&whitespaces[3][0]);
+//	__m128i w0 = _mm_loadu_si128((const __m128i *)&whitespaces[0][0]);
+//	__m128i w1 = _mm_loadu_si128((const __m128i *)&whitespaces[1][0]);
+//	__m128i w2 = _mm_loadu_si128((const __m128i *)&whitespaces[2][0]);
+//	__m128i w3 = _mm_loadu_si128((const __m128i *)&whitespaces[3][0]);
+//
+//	for (;;) {
+//		__m128i s = _mm_loadu_si128((const __m128i *)p);
+//		__m128i x = _mm_cmpeq_epi8(s, w0);
+//		x = _mm_or_si128(x, _mm_cmpeq_epi8(s, w1));
+//		x = _mm_or_si128(x, _mm_cmpeq_epi8(s, w2));
+//		x = _mm_or_si128(x, _mm_cmpeq_epi8(s, w3));
+//		unsigned short r = ~_mm_movemask_epi8(x);
+//		if (r == 0)	// all 16 characters are whitespace
+//			p += 16;
+//		else {		// some of characters may be non-whitespace
+//#ifdef _MSC_VER		// Find the index of first non-whitespace
+//			unsigned long offset;
+//			if (_BitScanForward(&offset, r))
+//				return p + offset;
+//#else
+//			if (r != 0)
+//				return p + __builtin_ffs(r) - 1;
+//#endif
+//		}
+//	}
+//}
+//
+//#endif // RAPIDJSON_SSE2
 
-	for (;;) {
-		__m128i s = _mm_loadu_si128((const __m128i *)p);
-		__m128i x = _mm_cmpeq_epi8(s, w0);
-		x = _mm_or_si128(x, _mm_cmpeq_epi8(s, w1));
-		x = _mm_or_si128(x, _mm_cmpeq_epi8(s, w2));
-		x = _mm_or_si128(x, _mm_cmpeq_epi8(s, w3));
-		unsigned short r = ~_mm_movemask_epi8(x);
-		if (r == 0)	// all 16 characters are whitespace
-			p += 16;
-		else {		// some of characters may be non-whitespace
-#ifdef _MSC_VER		// Find the index of first non-whitespace
-			unsigned long offset;
-			if (_BitScanForward(&offset, r))
-				return p + offset;
-#else
-			if (r != 0)
-				return p + __builtin_ffs(r) - 1;
-#endif
-		}
-	}
-}
-
-#endif // RAPIDJSON_SSE2
-
-#ifdef RAPIDJSON_SIMD
+//#ifdef RAPIDJSON_SIMD
 //! Template function specialization for InsituStringStream
-template<> inline void SkipWhitespace(InsituStringStream& stream) { 
-	stream.src_ = const_cast<char*>(SkipWhitespace_SIMD(stream.src_));
-}
+//template<> inline void SkipWhitespace(InsituStringStream& stream) { 
+//	stream.src_ = const_cast<char*>(SkipWhitespace_SIMD(stream.src_));
+//}
 
 //! Template function specialization for StringStream
-template<> inline void SkipWhitespace(StringStream& stream) {
-	stream.src_ = SkipWhitespace_SIMD(stream.src_);
-}
-#endif // RAPIDJSON_SIMD
+//template<> inline void SkipWhitespace(StringStream& stream) {
+//	stream.src_ = SkipWhitespace_SIMD(stream.src_);
+//}
+//#endif // RAPIDJSON_SIMD
 
 ///////////////////////////////////////////////////////////////////////////////
 // GenericReader

--- a/src/sofa/pbrpc/atomic.h
+++ b/src/sofa/pbrpc/atomic.h
@@ -1,95 +1,200 @@
 // Copyright (c) 2014 Baidu.com, Inc. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-
+//
+// Author: qinzuoyan01@baidu.com (Qin Zuoyan)
+// `atomic.h` serves as the header file for inline assembly functions in this project, providing support for assembly statements. 
+// Currently, some functions that support LoongArch architecture assembly instructions have been modified, including `atomic_add_ret_old`, `atomic_inc_ret_old`, and `atomic_dec_ret_old`.
+//
 #ifndef _SOFA_PBRPC_ATOMIC_H_
 #define _SOFA_PBRPC_ATOMIC_H_
 
-#if !defined(__i386__) && !defined(__x86_64__)
+#if !defined(__i386__) && !defined(__x86_64__) && !defined(__loongarch__)
 #error    "Arch not supprot!"
 #endif
 
 #include <stdint.h>
-
+#include <iostream>
 namespace sofa {
 namespace pbrpc {
 
 template <typename T>
 inline void atomic_inc(volatile T* n)
 {
-    asm volatile ("lock; incl %0;":"+m"(*n)::"cc");
+  
+    //std::cout<< "atomic_inc()" << std::endl;	
+    // asm volatile (" incl %0;":"+m"(*n)::"cc");
+    asm volatile (
+		    "ll.w $r12, %0\n\t"
+		    "addi.w $r12, $r12, 1\n\t"
+		    "sc.w $r12, %0"
+		    :"+m"(*n)
+		    ::"cc", "$r12"
+		    );
 }
 template <typename T>
 inline void atomic_dec(volatile T* n)
 {
-    asm volatile ("lock; decl %0;":"+m"(*n)::"cc");
+    //std::cout<< "atomic_dec()" << std::endl;
+    //asm volatile (" decl %0;":"+m"(*n)::"cc");
+    asm volatile (
+                    "ll.w $r12, %0\n\t"
+                    "addi.w $r12, $r12, -1\n\t"
+                    "sc.w $r12, %0"
+                    :"+m"(*n)
+                    ::"cc", "$r12"
+                    );
 }
 template <typename T>
 inline T atomic_add_ret_old(volatile T* n, T v)
 {
-    asm volatile ("lock; xaddl %1, %0;":"+m"(*n),"+r"(v)::"cc");
+    T* k = &v;
+    T temp = *n;
+    //std::cout<< "atomic_add_ret_old()" << std::endl;
+    //std::cout <<"n=" <<*n <<"v="<<v<<"temp="<<temp<<std::endl;
+    //asm volatile (" xaddl %1, %0;":"+m"(*n),"+r"(v)::"cc");
+    asm volatile(
+    "ll.w $r12, %[n]\n\t"
+    "add.w $r12, $r12, %[v]\n\t"
+    "add.w %[v], $r0, %[temp]\n\t"
+    "sc.w  $r12, %[n] \n\t"
+    : [n] "+m" (*n), [v]"+r"(v), [k] "+m" (*k),[temp]"+r"(temp)
+    :: "$r12", "$r13", "cc"
+    );
+    //std::cout <<"n=" <<*n <<"v="<<v<<"temp"<<temp<<std::endl; 
     return v;
 }
 template <typename T>
 inline T atomic_inc_ret_old(volatile T* n)
 {
     T r = 1;
-    asm volatile ("lock; xaddl %1, %0;":"+m"(*n), "+r"(r)::"cc");
+    T* k = &r;
+    T temp = *n;
+    //std::cout<< "atomic_inc_ret_old()" << std::endl;
+    //std::cout <<"n=" <<*n <<"r="<<r<<std::endl;
+    // asm volatile (" xaddl %1, %0;":"+m"(*n), "+r"(r)::"cc");
+    asm volatile(
+    "ll.w $r12, %[n]\n\t"
+    "add.w $r12, $r12, %[r]\n\t"
+    "add.w %[r], $r0, %[temp]\n\t"
+    "sc.w  $r12, %[n] \n\t"
+    : [n] "+m" (*n), [r]"+r"(r), [k] "+m" (*k),[temp]"+r"(temp)
+    :: "$r12", "$r13", "cc"
+    );
+    //std::cout <<"n=" <<*n <<"r="<<r<<std::endl;
     return r;
 }
 template <typename T>
 inline T atomic_dec_ret_old(volatile T* n)
 {
     T r = (T)-1;
-    asm volatile ("lock; xaddl %1, %0;":"+m"(*n), "+r"(r)::"cc");
+    T* k = &r;
+    T temp = *n;
+    //std::cout<< "atomic_dec_ret_old()" << std::endl;
+    //std::cout <<"n=" <<*n <<"r="<<r<<std::endl;
+    //asm volatile (" xaddl %1, %0;":"+m"(*n), "+r"(r)::"cc");
+    asm volatile(
+    "ll.w $r12, %[n]\n\t"
+    "add.w $r12, $r12, %[r]\n\t"
+    "add.w %[r], $r0, %[temp]\n\t"
+    "sc.w  $r12, %[n] \n\t"
+    : [n] "+m" (*n), [r]"+r"(r), [k] "+m" (*k),[temp]"+r"(temp)
+    :: "$r12", "$r13", "cc"
+    );
+    //std::cout <<"n=" <<*n <<"r="<<r<<std::endl;
     return r;
 }
 template <typename T>
 inline T atomic_add_ret_old64(volatile T* n, T v)
 {
-    asm volatile ("lock; xaddq %1, %0;":"+m"(*n),"+r"(v)::"cc");
+    //std::cout<< "atomic_add_ret_old64()" << std::endl;
+    //asm volatile (" xaddq %1, %0;":"+m"(*n),"+r"(v)::"cc");
     return v;
 }
 template <typename T>
 inline T atomic_inc_ret_old64(volatile T* n)
 {
     T r = 1;
-    asm volatile ("lock; xaddq %1, %0;":"+m"(*n), "+r"(r)::"cc");
+    //std::cout<< "atomic_inc_ret_old64()" << std::endl;
+    //asm volatile (" xaddq %1, %0;":"+m"(*n), "+r"(r)::"cc");
     return r;
 }
 template <typename T>
 inline T atomic_dec_ret_old64(volatile T* n)
 {
+    //std::cout<< "atomic_dec_ret_old64()" << std::endl;
     T r = (T)-1;
-    asm volatile ("lock; xaddq %1, %0;":"+m"(*n), "+r"(r)::"cc");
+    //asm volatile ("xaddq %1, %0;":"+m"(*n), "+r"(r)::"cc");
     return r;
 }
 template <typename T>
 inline void atomic_add(volatile T* n, T v)
 {
-    asm volatile ("lock; addl %1, %0;":"+m"(*n):"r"(v):"cc");
+    //std::cout<< "atomic_add()" << std::endl;
+    //asm volatile (" addl %1, %0;":"+m"(*n):"r"(v):"cc");
+    T* k = &v;
+    asm volatile (
+	"ll.w $r12, %1"	
+	"add.w $r12, %0, %1"
+	"sc.w $r12, %2"
+	: "+m"(*n), "+r"(v), "+m"(k)
+	::"cc"
+		    );
 }
 template <typename T>
 inline void atomic_sub(volatile T* n, T v)
 {
-    asm volatile ("lock; subl %1, %0;":"+m"(*n):"r"(v):"cc");
+    std::cout<< "atomic_sub()" << std::endl;
+    //asm volatile (" subl %1, %0;":"+m"(*n):"r"(v):"cc");
 }
 template <typename T, typename C, typename D>
 inline T atomic_cmpxchg(volatile T* n, C cmp, D dest)
 {
-    asm volatile ("lock; cmpxchgl %1, %0":"+m"(*n), "+r"(dest), "+a"(cmp)::"cc");
+    //std::cout<< "atomic_cmpxchg()" << std::endl;
+    //std::cout<< "n=" << *n << "cmp=" << cmp << "dest=" << dest << std::endl;
+    //asm volatile (" cmpxchgl %1, %0":"+m"(*n), "+r"(dest), "+a"(cmp)::"cc");
+    // n == cmp ? n=dest:cmp=n
+    //C* k = &cmp;
+    if (*n == cmp) {
+      *n = dest;
+    } else {
+      cmp = *n;
+    }
+   // asm volatile (
+   //		    " ll.w $r12, %0\n\t"
+   //		    " beq  $r12, %2, equal \n\t"
+   //		    //" b end\n\t"
+   //                    
+   //		    //" end:\n\t"
+                    //" sc.w $r12, %3\n\t"
+
+   //		    " equal:\n\t"
+		    //" sc.w %1, %0\n\t"
+		    
+   //		    :"+m"(*n), "+r"(dest), "+r"(cmp), "+m"(*k)
+   //		    ::"cc"
+   //		    );
+    //std::cout<< "n=" << *n << "cmp=" << cmp << "dest=" << dest << std::endl;
     return cmp;
 }
 // return old value
 template <typename T>
 inline T atomic_swap(volatile T* lockword, T value)
 {
-    asm volatile ("lock; xchg %0, %1;" : "+r"(value), "+m"(*lockword));
+    //std::cout<< "atomic_swap()" << std::endl;
+    T temp = *lockword;
+    //asm volatile (" xchg %0, %1;" : "+r"(value), "+m"(*lockword));
+    asm volatile(
+	"sc.w  %0, %1 \n\t"
+        "add.w %0, $r0, %2\n\t"
+	:"+r"(value), "+m"(*lockword), "+r"(temp)
+		    );
     return value;
 }
 template <typename T, typename E, typename C>
 inline T atomic_comp_swap(volatile T* lockword, E exchange, C comperand)
 {
+    //std::cout<< "atomic_comp_swap()" << std::endl;
     return atomic_cmpxchg(lockword, comperand, exchange);
 }
 

--- a/src/sofa/pbrpc/smart_ptr/detail/sp_counted_base.hpp
+++ b/src/sofa/pbrpc/smart_ptr/detail/sp_counted_base.hpp
@@ -13,7 +13,7 @@
 #ifndef _SOFA_PBRPC_SMART_PTR_DETAIL_SP_COUNTED_BASE_
 #define _SOFA_PBRPC_SMART_PTR_DETAIL_SP_COUNTED_BASE_
 
-#include <sofa/pbrpc/smart_ptr/detail/sp_counted_base_gcc_x86.hpp>
+#include <sofa/pbrpc/smart_ptr/detail/sp_counted_base_gcc_loongarch64.hpp>
 
 #endif // _SOFA_PBRPC_SMART_PTR_DETAIL_SP_COUNTED_BASE_
 


### PR DESCRIPTION
Bypassed the x86 vector optimization section not supported by longarch in reader. h
Added embedded assembly instructions based on the Loongarch instruction set in atom. h
Added sp_ Counted_ Base_ Gcc_ Loongarch64.hpp, add the corresponding Loongarch instruction to the x86 instruction set